### PR TITLE
Create trueimage-backend-poc-public.jwks

### DIFF
--- a/trueimage-backend-poc-public.jwks
+++ b/trueimage-backend-poc-public.jwks
@@ -1,0 +1,11 @@
+{
+"keys": [
+{
+  "kty": "RSA",
+  "e": "AQAB",
+  "kid": "0e4b1297-abc7-4978-bf72-91ab7d342f13",
+  "alg": "RS384",
+  "n": "xmcz15I25-ogyYel9MM03P9mTCduXhQuHflqMxdNbt7a2ZYWW3ZmldVKkVqhq-phnrvtOLc7t54pDJL3Se5DsYpkK7v0V8KXRTu1GlgtXIAvtCDUSNPG5FT6YMAcpw6hvrhyPYwVAMZAn-L04Suj6v1bCRhy6OkzvZyR9LqA4LHa1vdM_UzNO-9PoM7r7icVJUE41mSmi2zl5Z45MATdm8icr6_Y7EqwyaqNOiWlqsIWssD4hnT4lwJvKi75GMhKOOxW19WcJ93ajmX2_L7E4Sg9twc04lOjYYXXnqqLXZ7EsaIqSW_hfrWm4aIY6IVBsVc7AjqwwWoc-WoGxT5gOQ"
+}
+]
+}


### PR DESCRIPTION
This is a copy of seal-backend-poc-public.jwks, and once we are sure the system is using the new path we can remove the old one.